### PR TITLE
feat: add classic and freestyle mode options

### DIFF
--- a/src/components/PromptResult.svelte
+++ b/src/components/PromptResult.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
     import { fade } from 'svelte/transition'
+    import type { Mode } from '../types/mode.type'
 
     export let prompt: string
     export let isLocked: boolean
     export let isReady: boolean
     export let lockPrompt: () => void
     export let deletePrompt: () => void
+    export let mode: Mode
 </script>
 
 <style>
@@ -37,13 +39,15 @@
     <div transition:fade>
         <h4 class="prompt">
             {prompt}
-            <button on:click={lockPrompt} class="secondary-button prompt-lock">
-                {#if isLocked}Unlock{:else}Lock me{/if}
-            </button>
-            <button
-                on:click={deletePrompt}
-                disabled={isLocked}
-                class="secondary-button delete-button">Delete</button>
+            {#if mode === 'freestyle'}
+                <button on:click={lockPrompt} class="secondary-button prompt-lock">
+                    {#if isLocked}Unlock{:else}Lock me{/if}
+                </button>
+                <button
+                    on:click={deletePrompt}
+                    disabled={isLocked}
+                    class="secondary-button delete-button">Delete</button>
+            {/if}
         </h4>
     </div>
 {/if}

--- a/src/pages/Draw.svelte
+++ b/src/pages/Draw.svelte
@@ -9,6 +9,7 @@
 <script lang="ts">
     import { promptsData } from '../data/prompts'
     import { getRandomInt } from '../helpers/mathsHelpers'
+    import type { Mode } from '../types/mode.type'
 
     import CategorySelect from '../components/CategorySelect.svelte'
     import PromptResult from '../components/PromptResult.svelte'
@@ -36,6 +37,7 @@
     ]
 
     let isReady = false
+    let mode: Mode = 'classic'
 
     const generate = () => {
         promptsArray = promptsArray.map(prompt => {
@@ -53,7 +55,15 @@
 
     const deletePrompt = (index: number) =>
         (promptsArray = promptsArray.filter((_p, i) => i !== index))
+
+    const switchMode = (newMode: Mode) => (mode = newMode)
 </script>
+
+<style>
+    .active-mode {
+        background-color: goldenrod;
+    }
+</style>
 
 <nav><a href="/develop">Develop</a> <a href="/about">About</a></nav>
 
@@ -61,6 +71,16 @@
 <h2>Categories</h2>
 
 <div class="generator-container">
+    <div>
+        <!-- This class: syntax means 'if mode is classic, add the active-mode class' -->
+        <button
+            class:active-mode={mode === 'classic'}
+            on:click={() => switchMode('classic')}>Classic</button>
+        <button
+            class:active-mode={mode === 'freestyle'}
+            on:click={() => switchMode('freestyle')}>Freestyle</button>
+        <!-- Is it better to have radio inputs? -->
+    </div>
     {#each promptsArray as prompt, i}
         <CategorySelect
             label={prompt + String(i)}
@@ -71,7 +91,8 @@
             lockPrompt={() => (prompt.isLocked = !prompt.isLocked)}
             deletePrompt={() => deletePrompt(i)}
             {isReady}
-            isLocked={prompt.isLocked} />
+            isLocked={prompt.isLocked}
+            {mode} />
     {/each}
 
     <button on:click={generate}>Generate!</button>

--- a/src/types/mode.type.ts
+++ b/src/types/mode.type.ts
@@ -1,0 +1,1 @@
+export type Mode = 'classic' | 'freestyle'


### PR DESCRIPTION
At the moment, these just toggle the ability to lock and delete categories/prompts. We'll have to figure out what happens when you switch between them. Is classic mode always going to have the same four categories or can the user choose from a set number of dropdowns? When switching between modes, should the state of the 'freestyle' inputs persist, or get reset to a default? etc.